### PR TITLE
Add option to include lfs file hashes in RO-Crate output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # arc-export
-Automatic building of a Docker container for exporting ARCs to Arc.json
+Automatic building of a Docker container for exporting ARCs to various other ARC representations
 
 # Develop
 
@@ -23,6 +23,11 @@ git submodule update
 
 Note that the submodules are set on a specific commit, so **do not update them**.
 
+To execute the tests run:
+```shell
+dotnet test
+```
+
 # Setup
 
 ## local docker build
@@ -45,9 +50,10 @@ docker run -v C:\Repos\ArcRepo:/arc ghcr.io/nfdi4plants/arc-export:main /arc-exp
 
 Output format can be specified with the `-f` flag, followed by one of the following:
 
-- `isa-json` will produce a `arc-isa.json` file
-- `rocrate-metadata` will produce a `arc-ro-crate-metadata.json` file
-- `summary-markdown` will produce a `arc-summary.md` file
+- `isa-json` will produce an `arc-isa.json` file following the [ISA-JSON](https://isa-specs.readthedocs.io/en/latest/isajson.html#investigation-schema-json) specification
+- `rocrate-metadata` will produce an `arc-ro-crate-metadata.json` file following the [ARC RO-Crate profile](https://github.com/nfdi4plants/arc-ro-crate-profile)
+- `summary-markdown` will produce an `arc-summary.md` file
+- (experimental) `rocrate-metadata-lfs` will produce an `arc-ro-crate-metadata.json` file following the [ARC RO-Crate profile](https://github.com/nfdi4plants/arc-ro-crate-profile), where all objects of type `File` which are tracked by git-lfs additionally contain the according SHA256 hash 
 
 E.g. 
 
@@ -55,13 +61,13 @@ E.g.
 docker run -v C:\Repos\ArcRepo:/arc arc-export:latest /arc-export -p arc -f rocrate-metadata -f isa-json -f summary-markdown
 ```
 
-will produce all three output files.
+will produce all three basic output files.
 
 ## Help
 
 ```cli
 USAGE: arc-export [--help] --arc-directory <path> [--out-directory <path>]
-                  [--output-format <isa-json|rocrate-metadata|summary-markdown>]
+                  [--output-format <isa-json|rocrate-metadata|rocrate-metadata-lfs|summary-markdown>]
 
 OPTIONS:
 

--- a/src/arc-export/CLIArgs.fs
+++ b/src/arc-export/CLIArgs.fs
@@ -6,6 +6,7 @@ open System.IO
 type OutputFormat =
     | ISA_Json
     | ROCrate_Metadata
+    | ROCrate_Metadata_LFS
     | Summary_Markdown
 
 type CliArguments =

--- a/src/arc-export/GitLFS.fs
+++ b/src/arc-export/GitLFS.fs
@@ -1,0 +1,126 @@
+﻿module GitLFS
+
+open System.Diagnostics
+open System.Runtime.InteropServices
+open System.IO
+
+let [<Literal>] oidPattern = """(?<=oid )(?<HashType>\S+):(?<HashValue>\S+)"""
+let [<Literal>] sizePattern = """(?<=size )(?<Size>\d+)"""
+let [<Literal>] versionPattern = """(?<=version )(?<Version>\S+)"""
+
+let tryMatch (pattern: string) (input: string) =
+    let regex = System.Text.RegularExpressions.Regex(pattern)
+    let result = regex.Match(input)
+    if result.Success then
+        Some result
+    else
+        None
+
+type Hash = 
+    | SHA256 of string
+
+    //static member fromString (s: string) : Hash =
+    //    if s.StartsWith("sha256:") then
+    //        SHA256 (s.Substring(7))
+    //    else
+    //        failwith "Invalid hash format. Expected sha256: prefix."
+
+type GitLFSObject = 
+    { 
+        Version: string
+        Hash: Hash
+        Size: int64
+    }
+
+    static member fromString (s: string) : GitLFSObject =
+        let parts = s.Split ([| '\n' |], 3, System.StringSplitOptions.RemoveEmptyEntries)
+        if parts.Length <> 3 then
+            failwith "Invalid Git LFS object string format."
+        
+        let version = 
+            parts
+            |> Array.pick (fun (line : string) -> 
+                tryMatch versionPattern line 
+                |> Option.map (fun m -> m.Groups.["Version"].Value)               
+            )
+        let hash = 
+            parts
+            |> Array.pick (fun (line : string) -> 
+                tryMatch oidPattern line
+                |> Option.map (fun m -> 
+                    let hashType = m.Groups.["HashType"].Value
+                    let hashValue = m.Groups.["HashValue"].Value
+                    if hashType = "sha256" then
+                        Hash.SHA256 hashValue
+                    else
+                        failwithf "Unsupported hash type: %s" hashType
+                )
+            )
+        let size = 
+            parts
+            |> Array.pick (fun (line : string) -> 
+                tryMatch sizePattern line
+                |> Option.map (fun m -> 
+                    match System.Int64.TryParse(m.Groups.["Size"].Value) with
+                    | true, size -> size
+                    | _ -> failwith "Invalid size format."
+                )
+            )
+        { Version = version; Hash = hash; Size = size }
+
+
+let executeGitCommandWithResponse (repoDir : string) (command : string) =
+
+    let procStartInfo = 
+        ProcessStartInfo(
+            WorkingDirectory = repoDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            FileName = "git",
+            Arguments = command
+        )
+        
+    let outputs = System.Collections.Generic.List<string>()
+    let outputHandler (_sender:obj) (args:DataReceivedEventArgs) = 
+        if (args.Data = null |> not) then
+            outputs.Add(args.Data)
+            printfn ($"GIT: {args.Data}")
+        
+    let errorHandler (_sender:obj) (args:DataReceivedEventArgs) =  
+        if (args.Data = null |> not) then
+            let msg = args.Data.ToLower()
+            outputs.Add(args.Data)
+            printfn ($"GIT: {args.Data}")
+        
+    let p = new Process(StartInfo = procStartInfo)
+
+    p.OutputDataReceived.AddHandler(DataReceivedEventHandler outputHandler)
+    p.ErrorDataReceived.AddHandler(DataReceivedEventHandler errorHandler)
+    p.Start() |> ignore
+    p.BeginOutputReadLine()
+    p.BeginErrorReadLine()
+    p.WaitForExit()
+    outputs
+
+/// Executes Git command.
+let executeGitCommand (repoDir : string) (command : string) =
+        
+    executeGitCommandWithResponse repoDir command |> ignore
+
+let executeGitLFSHashCommand (repoDir : string) (filePath : string) = 
+    // or "git cat-file -p :assays/measurement1/dataset/proteomics_result.csv"
+    let p = $"{filePath.Trim().Replace('\\','/')}"
+    executeGitCommandWithResponse repoDir $"lfs pointer --file {p}"
+
+let tryGetGitLFSObject (repoDir : string) (filePath : string) =
+    let output = executeGitLFSHashCommand repoDir filePath
+    if output.Count = 0 then
+        None
+    else
+        try
+            Some (GitLFSObject.fromString (String.concat "\n" output))
+        with
+        | ex -> 
+            printfn "Error parsing Git LFS object: %s" ex.Message
+            None

--- a/src/arc-export/Program.fs
+++ b/src/arc-export/Program.fs
@@ -60,6 +60,9 @@ try
         Writers.write_isa_json outDir arc
 
     if outputFormats |> List.contains CLIArgs.OutputFormat.ROCrate_Metadata then
+        Writers.write_ro_crate_metadata outDir arc
+
+    if outputFormats |> List.contains CLIArgs.OutputFormat.ROCrate_Metadata_LFS then
         Writers.write_ro_crate_metadata_LFSHashes arcPath outDir arc
 
     if outputFormats |> List.contains CLIArgs.OutputFormat.Summary_Markdown then

--- a/src/arc-export/Program.fs
+++ b/src/arc-export/Program.fs
@@ -60,7 +60,7 @@ try
         Writers.write_isa_json outDir arc
 
     if outputFormats |> List.contains CLIArgs.OutputFormat.ROCrate_Metadata then
-        Writers.write_ro_crate_metadata outDir arc
+        Writers.write_ro_crate_metadata_LFSHashes arcPath outDir arc
 
     if outputFormats |> List.contains CLIArgs.OutputFormat.Summary_Markdown then
         Writers.write_arc_summary_markdown outDir arc

--- a/src/arc-export/arc-export.fsproj
+++ b/src/arc-export/arc-export.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="GitLFS.fs" />
     <Compile Include="Defaults.fs" />
     <Compile Include="CLIArgs.fs" />
     <Compile Include="PersonCleaning.fs" />

--- a/tests/ExportTests.fsproj
+++ b/tests/ExportTests.fsproj
@@ -14,12 +14,11 @@
     <Compile Include="TestUtils.fs" />
     <Compile Include="ReferenceObjects.fs" />
     <Compile Include="TestObjects.fs" />
+    <Compile Include="LFSPointerTests.fs" />
     <Compile Include="GitSubmoduleTests.fs" />
     <Compile Include="CLITests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
-  <ItemGroup />
 
   <ItemGroup>
     <PackageReference Include="Fake.Core.Process" Version="6.0.0" />

--- a/tests/LFSPointerTests.fs
+++ b/tests/LFSPointerTests.fs
@@ -1,0 +1,49 @@
+﻿module LFSPointerTests
+
+open GitLFS
+open Xunit
+
+let missingLFSOutput = """GIT: open assays/MassHunter_targets/dataset/./assays/MassHunter_targets/dataset/QuantReports/22-0005_exp001.batch_a.bin/190614_QuantReport_ISTD_DB.xlsx: The system cannot find the path specified.
+Error parsing Git LFS object: Invalid Git LFS object string format.
+No Git LFS object found for assays/MassHunter_targets/dataset/./assays/MassHunter_targets/dataset/QuantReports/22-0005_exp001.batch_a.bin/190614_QuantReport_ISTD_DB.xlsx"""
+
+let correctLFSOutput = """GIT: Git LFS pointer for assays/RNASeq/dataset/DB_097_CAMMD_CAGATC_L001_R1_001.fastq.gz
+GIT: version https://git-lfs.github.com/spec/v1
+GIT: oid sha256:53accc2afcca23e16f97ba977e3414f902ffcf9685adda86db93825d7d07bbd7
+GIT: size 135
+GIT:"""
+
+let correctLFSObject = 
+    { Version = "https://git-lfs.github.com/spec/v1"
+      Hash = SHA256 "53accc2afcca23e16f97ba977e3414f902ffcf9685adda86db93825d7d07bbd7"
+      Size = 135L }
+
+let fixtureLFSFilePath = "assays/measurement1/dataset/proteomics_result.csv"
+
+let fixtureLFSObject = 
+    { Version = "https://git-lfs.github.com/spec/v1"
+      Hash = SHA256 "01bb750bd981905d7065d48943567869570597745c4478bde4f7dbee16be8e3d"
+      Size = 95710L }
+
+
+[<Fact>]
+let ``Can correctly parse lfs pointer result`` () = 
+    Assert.Equal(
+        GitLFS.GitLFSObject.tryFromString correctLFSOutput,
+        Some correctLFSObject
+    )
+
+[<Fact>]
+let ``Returns None for wrong lfs pointer result`` () = 
+    Assert.Equal(
+        GitLFS.GitLFSObject.tryFromString missingLFSOutput,
+        None
+    )
+
+[<Fact>]
+let ``Can correctly retreive and parse lfs pointer`` () = 
+    Assert.Equal(
+        GitLFS.tryGetGitLFSObject "fixtures/ArcPrototype" fixtureLFSFilePath,
+        Some fixtureLFSObject
+    )
+    

--- a/tests/LFSPointerTests.fs
+++ b/tests/LFSPointerTests.fs
@@ -29,21 +29,21 @@ let fixtureLFSObject =
 [<Fact>]
 let ``Can correctly parse lfs pointer result`` () = 
     Assert.Equal(
-        GitLFS.GitLFSObject.tryFromString correctLFSOutput,
-        Some correctLFSObject
+        Some correctLFSObject,        
+        GitLFS.GitLFSObject.tryFromString correctLFSOutput
     )
 
 [<Fact>]
 let ``Returns None for wrong lfs pointer result`` () = 
     Assert.Equal(
-        GitLFS.GitLFSObject.tryFromString missingLFSOutput,
-        None
+        None,
+        GitLFS.GitLFSObject.tryFromString missingLFSOutput      
     )
 
 [<Fact>]
 let ``Can correctly retreive and parse lfs pointer`` () = 
     Assert.Equal(
-        GitLFS.tryGetGitLFSObject "fixtures/ArcPrototype" fixtureLFSFilePath,
-        Some fixtureLFSObject
+        Some fixtureLFSObject,
+        GitLFS.tryGetGitLFSObject "fixtures/ArcPrototype" fixtureLFSFilePath       
     )
     


### PR DESCRIPTION
In some applications, like Dataset publications, robustness and assurance of integrity of the data and its metadata are of big importance. One component for this can be file hashes, against which the file content can be checked. This also plays a role in how git lfs can identify the correct blob for a given file path.

This PR therefore adds a new target format `rocrate-metadata-lfs`, which contains the SHA256 file hashes for files tracked through git-lfs. When calling this target the internal workflow is as follows:

- Read ARC Scaffold
- Parse to In-Memory RO-Crate-Metadata
- For all annotated [File](https://github.com/nfdi4plants/isa-ro-crate-profile/blob/release/profile/isa_ro_crate.md#data) objects, call `git lfs pointer`
- Parse result and set SHA256 Hash for property [sha256](https://schema.org/sha256)
- Write RO-Crate to `ro-crate-metadata.json` as usual

Result looks this this:

```json
{
  "@id": "studies/MaterialPreparation/resources/Sample2_714ca2b7-22b7-4f69-b83d-9165f624da25.png",
  "@type": "File",
  "name": "studies/MaterialPreparation/resources/Sample2_714ca2b7-22b7-4f69-b83d-9165f624da25.png",
  "sha256": "def1b6a75b2ac6dcb0e9f01545354eed89204f3a400ff0829de7ee9bfb31fc0a"
}
```

