### PR TITLE
Issues with generating arc-ro-crate-metadata.json with sha key

### DIFF
--- a/src/arc-export/GitLFS.fs
+++ b/src/arc-export/GitLFS.fs
@@ -55,7 +55,7 @@ type GitLfsFile = {
     version: string 
 }
 
-type GitLfsJson = {
+type GitLfsFiles = {
     files: GitLfsFile []
 }
 
@@ -63,7 +63,7 @@ let deserializeGitLfsJson (json: string) =
     let options = JsonSerializerOptions()
     options.PropertyNameCaseInsensitive <- true
 
-    JsonSerializer.Deserialize<GitLfsJson>(json, options)
+    JsonSerializer.Deserialize<GitLfsFiles>(json, options)
 
 let [<Literal>] oidPattern = """(?<=oid )(?<HashType>\S+):(?<HashValue>\S+)"""
 let [<Literal>] sizePattern = """(?<=size )(?<Size>\d+)"""

--- a/src/arc-export/GitLFS.fs
+++ b/src/arc-export/GitLFS.fs
@@ -4,6 +4,67 @@ open System.Diagnostics
 open System.Runtime.InteropServices
 open System.IO
 
+open System
+open System.IO
+
+/// This is a function to strictly check if a file is a git lfs pointer file. It was created due to
+/// system out of memory issues with the tryfromString function
+let isGitLfsPointerFile (filePath: string) =
+    if not (File.Exists filePath) then
+        printfn "file for Path does not exist: %s" filePath
+        false
+    else
+        try
+            // LFS pointer files are small (usually < 1 KB)
+            let fileInfo = FileInfo(filePath)
+            if fileInfo.Length > 2048L then
+                false
+            else
+                let lines = File.ReadLines(filePath) |> Seq.truncate 3 |> Seq.toArray
+
+                if lines.Length < 3 then
+                    false
+                else
+                    let hasVersion =
+                        lines.[0].StartsWith("version https://git-lfs.github.com/spec/")
+
+                    let hasOid =
+                        lines |> Array.exists (fun l -> l.StartsWith("oid sha256:"))
+
+                    let hasSize =
+                        lines |> Array.exists (fun l -> l.StartsWith("size "))
+
+                    hasVersion && hasOid && hasSize
+        with
+        | _ -> false
+
+open System.IO
+open System.Text.Json
+
+open System.Text.Json.Serialization
+
+
+type GitLfsFile = { 
+    name: string
+    size: int64
+    checkout: bool
+    downloaded: bool
+    [<JsonPropertyName("oid_type")>]
+    oidType: string
+    oid: string
+    version: string 
+}
+
+type GitLfsJson = {
+    files: GitLfsFile []
+}
+
+let deserializeGitLfsJson (json: string) =
+    let options = JsonSerializerOptions()
+    options.PropertyNameCaseInsensitive <- true
+
+    JsonSerializer.Deserialize<GitLfsJson>(json, options)
+
 let [<Literal>] oidPattern = """(?<=oid )(?<HashType>\S+):(?<HashValue>\S+)"""
 let [<Literal>] sizePattern = """(?<=size )(?<Size>\d+)"""
 let [<Literal>] versionPattern = """(?<=version )(?<Version>\S+)"""
@@ -34,9 +95,7 @@ type GitLFSObject =
 
     static member tryFromString (s: string) : GitLFSObject option =
         try 
-            let parts = s.Split ([| '\n' |], 3, System.StringSplitOptions.RemoveEmptyEntries)
-            if parts.Length <> 3 then
-                failwith "Invalid Git LFS object string format."
+            let parts = s.Split ([| "\n"; System.Environment.NewLine |], System.StringSplitOptions.RemoveEmptyEntries)
         
             let version = 
                 parts
@@ -70,9 +129,44 @@ type GitLFSObject =
             Some { Version = version; Hash = hash; Size = size }
         with
         | ex -> 
-            printfn "Error parsing Git LFS object: %s" ex.Message
+            printfn "Error parsing Git LFS object: %s - (%s)" ex.Message s
             None
 
+open System
+open System.Diagnostics
+open System.IO
+
+type CommandResult =
+    { ExitCode: int
+      StdOut: string
+      StdErr: string }
+
+let runGit (repoDir: string) (args: string) : CommandResult =
+    let psi =
+        ProcessStartInfo(
+            FileName = "git",
+            Arguments = args,
+            WorkingDirectory = repoDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        )
+
+    use proc = new Process(StartInfo = psi)
+
+    proc.Start() |> ignore
+
+    // Read both streams fully BEFORE waiting
+    let stdOut = proc.StandardOutput.ReadToEnd()
+    let stdErr = proc.StandardError.ReadToEnd()
+
+    proc.WaitForExit()
+
+    { ExitCode = proc.ExitCode
+      StdOut = stdOut
+      StdErr = stdErr }
+ 
 let executeGitCommandWithResponse (repoDir : string) (command : string) =
 
     let procStartInfo = 
@@ -89,7 +183,7 @@ let executeGitCommandWithResponse (repoDir : string) (command : string) =
     let outputHandler (_sender:obj) (args:DataReceivedEventArgs) = 
         if (args.Data = null |> not) then
             outputs.Add(args.Data)
-            printfn ($"GIT: {args.Data}")
+            // printfn ($"GIT: {args.Data}")
         
     let errorHandler (_sender:obj) (args:DataReceivedEventArgs) =  
         if (args.Data = null |> not) then
@@ -115,13 +209,15 @@ let executeGitCommand (repoDir : string) (command : string) =
 let executeGitLFSHashCommand (repoDir : string) (filePath : string) = 
     // or "git cat-file -p :assays/measurement1/dataset/proteomics_result.csv"
     let p = $"{filePath.Trim().Replace('\\','/')}"
-    executeGitCommandWithResponse repoDir $"lfs pointer --file {p}"
+    printfn "%s" p
+    executeGitCommandWithResponse repoDir $"lfs pointer --file=\"{p}\""
 
 /// Gets the Git LFS object from a pointer file by simply reading it.
 let tryGetGitLFSObjectFromPointerFile (repoDir : string) (filePath : string) =
     let fullPath = Path.Combine(repoDir, filePath)
-    if not (File.Exists fullPath) then
-        printfn "Git LFS pointer file not found: %s" fullPath
+    // check if file is pointer file
+    if isGitLfsPointerFile fullPath |> not then
+        
         None
     else
         File.ReadAllText fullPath
@@ -144,3 +240,21 @@ let tryGetGitLFSObject (repoDir : string) (filePath : string) =
     | None -> 
         // If that fails, try to get it from the actual file
         tryGetGitLFSObjectFromActualFile repoDir filePath
+
+let tryCreateGitLfsJson (repoDir: string) =
+    let output = 
+        runGit repoDir "lfs ls-files -j"
+    try
+        deserializeGitLfsJson output.StdOut
+        |> Some
+    with
+        | _ -> None
+
+let normalizePathToGitPath (p: string) =
+    p.Replace("\\", "/").Trim()
+    |> fun p -> if p.StartsWith "./" then p.Substring(2) else p
+    |> fun p -> p.Trim('/')
+
+let tryGetPathFromGitLfsJson (p: string) (arr: GitLfsFile []) =
+    arr
+    |> Array.tryFind (fun lfs -> lfs.name = normalizePathToGitPath p) 

--- a/src/arc-export/Writers.fs
+++ b/src/arc-export/Writers.fs
@@ -68,21 +68,21 @@ let write_ro_crate_metadata_LFSHashes (repoDir : string) (outDir: string) (arc: 
                         printfn "ERROR: File on path does not exist: %s" fullPath
             )
     | None ->
-        printfn "Oh No! Unable to generate git lfs json (`git lfs ls-files -j`)"
-    // graph.Nodes
-    // |> Seq.iteri (fun i n -> 
-    //     if LDFile.validate(n, ?context = graph.TryGetContext()) && not (n.Id.Contains("#")) && not (n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext()))  then
-    //         printfn "checking lfs for index %i - %s" i n.Id
-    //         match GitLFS.tryGetGitLFSObject repoDir n.Id with
-    //         | Some lfsHash ->
-    //             match lfsHash.Hash with
-    //             | GitLFS.Hash.SHA256 hash ->
-    //                 n.SetProperty(sha256, hash, ?context = graph.TryGetContext())
-    //             n.SetProperty(contentSize, $"{lfsHash.Size}b", ?context = graph.TryGetContext())
-    //         | None -> 
-    //             printfn "No Git LFS object found for %s" n.Id
-    //             ()
-    // )
+        printfn "Oh No! Unable to generate git lfs json (`git lfs ls-files -j`), consider updating git-lfs (>= v3.2.0). Trying to explicitly parse files instead."
+        graph.Nodes
+        |> Seq.iteri (fun i n -> 
+            if LDFile.validate(n, ?context = graph.TryGetContext()) && not (n.Id.Contains("#")) && not (n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext()))  then
+                printfn "checking lfs for index %i - %s" i n.Id
+                match GitLFS.tryGetGitLFSObject repoDir n.Id with
+                | Some lfsHash ->
+                    match lfsHash.Hash with
+                    | GitLFS.Hash.SHA256 hash ->
+                        n.SetProperty(sha256, hash, ?context = graph.TryGetContext())
+                    n.SetProperty(contentSize, $"{lfsHash.Size}b", ?context = graph.TryGetContext())
+                | None -> 
+                    printfn "No Git LFS object found for %s" n.Id
+                    ()
+        )
     graph.Compact_InPlace()
     let ro_crate_metadata = graph.ToROCrateJsonString(2)
     let ro_crate_metadata_path = Path.Combine(outDir, ro_crate_metadata_filename)

--- a/src/arc-export/Writers.fs
+++ b/src/arc-export/Writers.fs
@@ -19,6 +19,7 @@ let isa_json_filename = "arc-isa.json"
 let arc_summary_markdown_filename = "arc-summary.md"
 
 let write_ro_crate_metadata (outDir: string) (arc: ARC) =
+    printfn "It is writing here"
     printfn "Writing ARC RO-Crate metadata to %s" (Path.Combine(outDir, ro_crate_metadata_filename))
     if arc.Title.IsNone then
         arc.Title <- Some "Untitled ARC"
@@ -42,19 +43,46 @@ let write_ro_crate_metadata_LFSHashes (repoDir : string) (outDir: string) (arc: 
     let context = LDContext(baseContexts=ResizeArray[Context.initV1_1();customContextPart])
     graph.SetContext(context)
     graph.AddNode(ROCrate.metadataFileDescriptor)
-    graph.Nodes
-    |> Seq.iter (fun n -> 
-        if LDFile.validate(n, ?context = graph.TryGetContext()) && not (n.Id.Contains("#")) && not (n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext()))  then
-            match GitLFS.tryGetGitLFSObject repoDir n.Id with
-            | Some lfsHash ->
-                match lfsHash.Hash with
-                | GitLFS.Hash.SHA256 hash ->
-                    n.SetProperty(sha256, hash, ?context = graph.TryGetContext())
-                n.SetProperty(contentSize, $"{lfsHash.Size}b", ?context = graph.TryGetContext())
-            | None -> 
-                printfn "No Git LFS object found for %s" n.Id
-                ()
-    )
+    let gitlfsInfo = GitLFS.tryCreateGitLfsJson repoDir
+    match gitlfsInfo with
+    | Some info ->
+        graph.Nodes
+        |> Seq.iteri (fun i n -> 
+            if LDFile.validate(n, ?context = graph.TryGetContext()) && not (n.Id.Contains("#")) && not (n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext())) then
+                match GitLFS.tryGetPathFromGitLfsJson n.Id info.files with
+                | Some lfsFileInfo ->
+                    match lfsFileInfo.oidType with
+                    | "sha256" ->
+                        n.SetProperty(sha256, lfsFileInfo.oid, ?context = graph.TryGetContext())
+                    | _ -> 
+                        printfn "WARNING: Only oid_type sha256 is supported at the moment."
+                        ()
+                    n.SetProperty(contentSize, $"{lfsFileInfo.size}b", ?context = graph.TryGetContext())
+                | None -> 
+                    let fullPath = Path.Combine(repoDir, GitLFS.normalizePathToGitPath n.Id)
+                    // TODO: case-insensitive on windows, should be perfect match.
+                    match File.Exists(fullPath) with 
+                    | true ->
+                        printfn "WARNING: No Git LFS object found for %s" fullPath
+                    | false ->
+                        printfn "ERROR: File on path does not exist: %s" fullPath
+            )
+    | None ->
+        printfn "Oh No! Unable to generate git lfs json (`git lfs ls-files -j`)"
+    // graph.Nodes
+    // |> Seq.iteri (fun i n -> 
+    //     if LDFile.validate(n, ?context = graph.TryGetContext()) && not (n.Id.Contains("#")) && not (n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext()))  then
+    //         printfn "checking lfs for index %i - %s" i n.Id
+    //         match GitLFS.tryGetGitLFSObject repoDir n.Id with
+    //         | Some lfsHash ->
+    //             match lfsHash.Hash with
+    //             | GitLFS.Hash.SHA256 hash ->
+    //                 n.SetProperty(sha256, hash, ?context = graph.TryGetContext())
+    //             n.SetProperty(contentSize, $"{lfsHash.Size}b", ?context = graph.TryGetContext())
+    //         | None -> 
+    //             printfn "No Git LFS object found for %s" n.Id
+    //             ()
+    // )
     graph.Compact_InPlace()
     let ro_crate_metadata = graph.ToROCrateJsonString(2)
     let ro_crate_metadata_path = Path.Combine(outDir, ro_crate_metadata_filename)


### PR DESCRIPTION
I have an issue with having the download button for files in DataPLANT ARChive. @Freymaurer said this is because the arc-ro-crate-metadata.json is missing the sha key for the files. 

He also figured that arc-export resulted in a "Out of memory" error with the current regex logic and replaced it with `git lfs ls-files -j` instead to generate arc-ro-crate-metada.json with sha key. 

This works now, for most files. However, for some files which do exist, it results in `No Git LFS object found for` and the corresponding file path. Eg. ./runs/morphomapper/analysis/2d_3d_comparison.svg

